### PR TITLE
Fix: Sign-in navigates to sync screen even with invalid credentials

### DIFF
--- a/apps/app-bible/src/features/auth/components/SignInForm.tsx
+++ b/apps/app-bible/src/features/auth/components/SignInForm.tsx
@@ -231,9 +231,6 @@ export function SignInForm({
           return;
         }
 
-        // Navigate to sync screen first, then start the sign-in process
-        navigation.navigate('SignInSync');
-
         // Try to sign in using fresh start method
         try {
           await signInWithFreshStart(email, password);
@@ -241,6 +238,8 @@ export function SignInForm({
             ENABLE_LOGGING,
             'SignInForm: User successfully authenticated with fresh start'
           );
+          // Navigate to sync screen only after successful authentication
+          navigation.navigate('SignInSync');
         } catch (error) {
           logger.error(ENABLE_LOGGING, 'Sign in error', error);
           const errorMessage =
@@ -260,7 +259,7 @@ export function SignInForm({
             return;
           }
 
-          // Other sign in error
+          // Other sign in error - stay on sign-in screen
           Alert.alert(t('common.error'), errorMessage);
         }
         return;


### PR DESCRIPTION
## Summary

Fixes EL-135

When a user attempts to sign in with invalid credentials (wrong email/password), the app incorrectly navigates to the `SignInSync` screen **before** validating the credentials.

## Changes

- [ ] Move navigation to `SignInSync` to after successful authentication
- [ ] Keep error handling on sign-in screen for failed attempts
- [ ] Ensure unverified email flow still navigates to VerifyCode screen

## Testing Checklist

- [ ] Sign in with correct credentials → Should navigate to sync screen
- [ ] Sign in with wrong password → Should show error on sign-in screen (no navigation)
- [ ] Sign in with wrong email → Should show error on sign-in screen (no navigation)
- [ ] Sign in with unverified email → Should navigate to VerifyCode screen
- [ ] Phone sign-in flow → Should remain unchanged (already correct)

fixes EL-135
