### PR TITLE
Get powersync connection working

### DIFF
--- a/apps/app-record/src/shared/auth/store/__tests__/authStore.test.ts
+++ b/apps/app-record/src/shared/auth/store/__tests__/authStore.test.ts
@@ -23,6 +23,13 @@ const setIsConnected = (value: boolean): void => {
   });
 };
 
+const setIsInitialized = (value: boolean): void => {
+  Object.defineProperty(mockPowerSyncSystem, 'isInitialized', {
+    configurable: true,
+    get: () => value,
+  });
+};
+
 describe('authStore', () => {
   const mockUser: User = {
     id: 'user-123',
@@ -78,7 +85,11 @@ describe('authStore', () => {
     } as any;
 
     mockPowerSyncSystem.disconnect = jest.fn().mockResolvedValue(undefined);
+    mockPowerSyncSystem.connect = jest.fn().mockResolvedValue(undefined);
+    mockPowerSyncSystem.execute = jest.fn().mockResolvedValue(undefined);
+    mockPowerSyncSystem.getAll = jest.fn().mockResolvedValue([]);
     setIsConnected(false);
+    setIsInitialized(true);
   });
 
   describe('initial state', () => {
@@ -296,6 +307,73 @@ describe('authStore', () => {
         newSession.user?.email
       );
     });
+
+    it('should update projects and connect PowerSync on SIGNED_IN event', async () => {
+      mockSupabase.auth.getSession = jest.fn().mockResolvedValue({
+        data: { session: null },
+        error: null,
+      });
+
+      await act(async () => {
+        await useAuthStore.getState().initialize();
+      });
+
+      expect(mockSupabase.auth.onAuthStateChange).toHaveBeenCalledTimes(1);
+      const authCalls = onAuthStateChangeMock.mock.calls[0];
+      if (!authCalls) {
+        throw new Error('Expected auth state change listener to be registered');
+      }
+      const listenerCallback = authCalls[0] as (
+        event: AuthChangeEvent,
+        session: Session | null
+      ) => void;
+
+      // Simulate SIGNED_IN event
+      await act(async () => {
+        listenerCallback('SIGNED_IN', mockSession);
+      });
+
+      // Wait for async operations
+      await waitFor(() => {
+        expect(mockPowerSyncSystem.execute).toHaveBeenCalled();
+      });
+
+      expect(mockPowerSyncSystem.execute).toHaveBeenCalledWith(
+        expect.stringContaining('UPDATE projects'),
+        [mockUser.id]
+      );
+      expect(mockPowerSyncSystem.getAll).toHaveBeenCalled();
+      expect(mockPowerSyncSystem.connect).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not update projects on non-SIGNED_IN events', async () => {
+      mockSupabase.auth.getSession = jest.fn().mockResolvedValue({
+        data: { session: mockSession },
+        error: null,
+      });
+
+      await act(async () => {
+        await useAuthStore.getState().initialize();
+      });
+
+      const authCalls = onAuthStateChangeMock.mock.calls[0];
+      if (!authCalls) {
+        throw new Error('Expected auth state change listener to be registered');
+      }
+      const listenerCallback = authCalls[0] as (
+        event: AuthChangeEvent,
+        session: Session | null
+      ) => void;
+
+      // Simulate TOKEN_REFRESHED event (should not trigger PowerSync operations)
+      act(() => {
+        listenerCallback('TOKEN_REFRESHED', mockSession);
+      });
+
+      // PowerSync operations should not be called for non-SIGNED_IN events
+      expect(mockPowerSyncSystem.execute).not.toHaveBeenCalled();
+      expect(mockPowerSyncSystem.connect).not.toHaveBeenCalled();
+    });
   });
 
   describe('signIn', () => {
@@ -392,6 +470,160 @@ describe('authStore', () => {
       expect(mockLogger.error).toHaveBeenCalledWith(
         'Sign in failed:',
         expect.any(Error)
+      );
+    });
+
+    it('should update projects with user_id after sign in', async () => {
+      const email = 'test@example.com';
+      const password = 'password123';
+
+      mockSupabase.auth.signInWithPassword = jest.fn().mockResolvedValue({
+        data: { session: mockSession, user: mockUser },
+        error: null,
+      });
+
+      await act(async () => {
+        await useAuthStore.getState().signIn(email, password);
+      });
+
+      expect(mockPowerSyncSystem.execute).toHaveBeenCalledWith(
+        expect.stringContaining('UPDATE projects'),
+        [mockUser.id]
+      );
+    });
+
+    it('should validate projects before connecting PowerSync', async () => {
+      const email = 'test@example.com';
+      const password = 'password123';
+
+      mockSupabase.auth.signInWithPassword = jest.fn().mockResolvedValue({
+        data: { session: mockSession, user: mockUser },
+        error: null,
+      });
+
+      await act(async () => {
+        await useAuthStore.getState().signIn(email, password);
+      });
+
+      expect(mockPowerSyncSystem.getAll).toHaveBeenCalledWith(
+        expect.stringContaining('SELECT id, created_by FROM projects'),
+        undefined
+      );
+    });
+
+    it('should connect PowerSync after sign in', async () => {
+      const email = 'test@example.com';
+      const password = 'password123';
+
+      mockSupabase.auth.signInWithPassword = jest.fn().mockResolvedValue({
+        data: { session: mockSession, user: mockUser },
+        error: null,
+      });
+      setIsConnected(false);
+
+      await act(async () => {
+        await useAuthStore.getState().signIn(email, password);
+      });
+
+      expect(mockPowerSyncSystem.connect).toHaveBeenCalledTimes(1);
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        'PowerSync connected after sign-in'
+      );
+    });
+
+    it('should not connect PowerSync if already connected', async () => {
+      const email = 'test@example.com';
+      const password = 'password123';
+
+      mockSupabase.auth.signInWithPassword = jest.fn().mockResolvedValue({
+        data: { session: mockSession, user: mockUser },
+        error: null,
+      });
+      setIsConnected(true);
+
+      await act(async () => {
+        await useAuthStore.getState().signIn(email, password);
+      });
+
+      expect(mockPowerSyncSystem.connect).not.toHaveBeenCalled();
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        'PowerSync already connected, skipping connection'
+      );
+    });
+
+    it('should handle PowerSync connection failure gracefully', async () => {
+      const email = 'test@example.com';
+      const password = 'password123';
+      const connectionError = new Error('Connection failed');
+
+      mockSupabase.auth.signInWithPassword = jest.fn().mockResolvedValue({
+        data: { session: mockSession, user: mockUser },
+        error: null,
+      });
+      mockPowerSyncSystem.connect = jest
+        .fn()
+        .mockRejectedValue(connectionError);
+      setIsConnected(false);
+
+      await act(async () => {
+        await useAuthStore.getState().signIn(email, password);
+      });
+
+      // Sign-in should still succeed despite PowerSync failure
+      const state = useAuthStore.getState();
+      expect(state.session).toBe(mockSession);
+      expect(state.user).toBe(mockUser);
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        'Failed to connect PowerSync after sign-in:',
+        connectionError
+      );
+    });
+
+    it('should skip PowerSync operations if not initialized', async () => {
+      const email = 'test@example.com';
+      const password = 'password123';
+
+      mockSupabase.auth.signInWithPassword = jest.fn().mockResolvedValue({
+        data: { session: mockSession, user: mockUser },
+        error: null,
+      });
+      setIsInitialized(false);
+
+      await act(async () => {
+        await useAuthStore.getState().signIn(email, password);
+      });
+
+      // Sign-in should still succeed
+      const state = useAuthStore.getState();
+      expect(state.session).toBe(mockSession);
+      expect(state.user).toBe(mockUser);
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        'PowerSync not initialized, skipping project update with user_id'
+      );
+    });
+
+    it('should handle projects with invalid created_by', async () => {
+      const email = 'test@example.com';
+      const password = 'password123';
+      const otherUserId = 'other-user-123';
+
+      mockSupabase.auth.signInWithPassword = jest.fn().mockResolvedValue({
+        data: { session: mockSession, user: mockUser },
+        error: null,
+      });
+      // Mock projects with invalid created_by
+      mockPowerSyncSystem.getAll = jest.fn().mockResolvedValue([
+        { id: 'project-1', created_by: mockUser.id },
+        { id: 'project-2', created_by: otherUserId }, // Invalid
+      ]);
+
+      await act(async () => {
+        await useAuthStore.getState().signIn(email, password);
+      });
+
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        'Projects with invalid created_by found (will be skipped on sync):',
+        [{ id: 'project-2', created_by: otherUserId }]
       );
     });
   });

--- a/apps/app-record/src/shared/auth/store/__tests__/authStore.test.ts
+++ b/apps/app-record/src/shared/auth/store/__tests__/authStore.test.ts
@@ -506,8 +506,7 @@ describe('authStore', () => {
       });
 
       expect(mockPowerSyncSystem.getAll).toHaveBeenCalledWith(
-        expect.stringContaining('SELECT id, created_by FROM projects'),
-        undefined
+        'SELECT id, created_by FROM projects WHERE deleted_at IS NULL'
       );
     });
 

--- a/apps/app-record/src/shared/auth/store/authStore.ts
+++ b/apps/app-record/src/shared/auth/store/authStore.ts
@@ -6,6 +6,88 @@ import { powerSyncSystem } from '@/shared/infrastructure/powersync/services/Powe
 import { logger } from '@/shared/utils/logger';
 import type { User, Session, AuthChangeEvent } from '@supabase/supabase-js';
 
+/**
+ * Update local projects with user_id after sign-in
+ * Only updates projects where created_by IS NULL to avoid overwriting existing assignments
+ */
+async function updateProjectsWithUserId(userId: string): Promise<void> {
+  if (!powerSyncSystem.isInitialized) {
+    logger.warn(
+      'PowerSync not initialized, skipping project update with user_id'
+    );
+    return;
+  }
+
+  try {
+    const result = await powerSyncSystem.execute(
+      `UPDATE projects 
+       SET created_by = ? 
+       WHERE created_by IS NULL`,
+      [userId]
+    );
+
+    logger.info('Updated projects with user_id', { userId, result });
+  } catch (error) {
+    logger.error('Failed to update projects with user_id:', error);
+    // Non-fatal: continue even if update fails
+  }
+}
+
+/**
+ * Validate that all local projects will pass RLS checks before syncing
+ * Checks that projects have created_by matching current user
+ */
+async function validateProjectsForSync(userId: string): Promise<void> {
+  if (!powerSyncSystem.isInitialized) {
+    return;
+  }
+
+  try {
+    const projects = await powerSyncSystem.getAll(
+      `SELECT id, created_by FROM projects WHERE deleted_at IS NULL`
+    );
+
+    const invalidProjects = projects.filter(
+      (p: { id: string; created_by: string | null }) =>
+        p.created_by !== null && p.created_by !== userId
+    );
+
+    if (invalidProjects.length > 0) {
+      logger.warn(
+        'Projects with invalid created_by found (will be skipped on sync):',
+        invalidProjects
+      );
+    }
+  } catch (error) {
+    logger.error('Failed to validate projects for sync:', error);
+    // Non-fatal: continue even if validation fails
+  }
+}
+
+/**
+ * Connect PowerSync after sign-in, with error handling
+ * Non-blocking: failures are logged but don't prevent sign-in
+ */
+async function connectPowerSyncAfterSignIn(): Promise<void> {
+  if (!powerSyncSystem.isInitialized) {
+    logger.warn('PowerSync not initialized, skipping connection after sign-in');
+    return;
+  }
+
+  if (powerSyncSystem.isConnected) {
+    logger.info('PowerSync already connected, skipping connection');
+    return;
+  }
+
+  try {
+    await powerSyncSystem.connect();
+    logger.info('PowerSync connected after sign-in');
+  } catch (error) {
+    logger.error('Failed to connect PowerSync after sign-in:', error);
+    // Non-fatal: user can still use app offline
+  }
+}
+
 interface AuthStoreState {
   user: User | null;
   session: Session | null;
@@ -69,7 +151,7 @@ export const useAuthStore = create<AuthStore>()(
 
             // Set up auth state change listener
             authStateChangeSubscription = supabase.auth.onAuthStateChange(
-              (event: AuthChangeEvent, session: Session | null) => {
+              async (event: AuthChangeEvent, session: Session | null) => {
                 logger.info(
                   `Auth state changed: ${event}`,
                   session?.user?.email
@@ -78,6 +160,14 @@ export const useAuthStore = create<AuthStore>()(
                   session,
                   user: session?.user ?? null,
                 });
+
+                // Handle SIGNED_IN event: update projects and connect PowerSync
+                if (event === 'SIGNED_IN' && session?.user) {
+                  const userId = session.user.id;
+                  await updateProjectsWithUserId(userId);
+                  await validateProjectsForSync(userId);
+                  await connectPowerSyncAfterSignIn();
+                }
               }
             );
           } catch (error) {
@@ -104,6 +194,14 @@ export const useAuthStore = create<AuthStore>()(
 
             set({ session: data.session, user: data.user });
             logger.info('User signed in successfully', email);
+
+            // Update projects with user_id, validate, and connect PowerSync
+            if (data.user) {
+              const userId = data.user.id;
+              await updateProjectsWithUserId(userId);
+              await validateProjectsForSync(userId);
+              await connectPowerSyncAfterSignIn();
+            }
           } catch (error) {
             const err =
               error instanceof Error ? error : new Error('Sign in failed');

--- a/apps/app-record/src/types/assets.d.ts
+++ b/apps/app-record/src/types/assets.d.ts
@@ -1,0 +1,4 @@
+declare module '*.png' {
+  const src: number;
+  export default src;
+}


### PR DESCRIPTION
## Summary
- Connect PowerSync automatically after successful sign-in.
- Ensure local `projects.created_by` is populated with the current Supabase `auth.uid()` before attempting sync.
- Add/update unit tests covering connection + validation behavior.

## Testing
- [ ] `pnpm --filter app-record test`
- [ ] `pnpm --filter app-record type-check`

fixes EL-172

Made with [Cursor](https://cursor.com)