### PR TITLE
fix(web-project-dashboard): use public RPC for Language Explorer (EL-216)

### DIFF
--- a/apps/web-project-dashboard/src/app/pages/LanguagesPage.test.tsx
+++ b/apps/web-project-dashboard/src/app/pages/LanguagesPage.test.tsx
@@ -1,0 +1,192 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { LanguagesPage } from './LanguagesPage';
+import type { ActiveProjectWithProgress } from '../../shared/hooks/query/projects';
+
+vi.mock('../../shared/services/supabase', () => ({
+  supabase: {
+    from: vi.fn(),
+    rpc: vi.fn(),
+  },
+  isSupabaseConnected: vi.fn(),
+}));
+
+vi.mock('../../shared/hooks/query/projects', () => ({
+  useActiveProjectsWithProgress: vi.fn(),
+}));
+
+vi.mock('../../features/landing-page/components/LandingNavbar', () => ({
+  LandingNavbar: (): React.ReactElement => <nav data-testid='landing-navbar' />,
+}));
+
+vi.mock('@/features/landing-page', () => ({
+  LandingFooter: (): React.ReactElement => (
+    <footer data-testid='landing-footer' />
+  ),
+}));
+
+import { useActiveProjectsWithProgress } from '../../shared/hooks/query/projects';
+
+type HookReturn = {
+  data?: ActiveProjectWithProgress[];
+  isLoading: boolean;
+};
+
+const mockUseActiveProjectsWithProgress =
+  useActiveProjectsWithProgress as unknown as ReturnType<typeof vi.fn>;
+
+function setHookReturn(value: HookReturn): void {
+  mockUseActiveProjectsWithProgress.mockReturnValue(value);
+}
+
+const sampleProjects: ActiveProjectWithProgress[] = [
+  {
+    project_id: 'p-1',
+    project_name: 'Alpha Project',
+    language_name: 'Bajhangi',
+    has_audio: true,
+    has_text: false,
+    completed_chapters: 100,
+    total_chapters: 200,
+    progress_percentage: 50,
+  },
+  {
+    project_id: 'p-2',
+    project_name: 'Beta Project',
+    language_name: 'Tagalog',
+    has_audio: false,
+    has_text: true,
+    completed_chapters: 1189,
+    total_chapters: 1189,
+    progress_percentage: 100,
+  },
+  {
+    project_id: 'p-3',
+    project_name: 'Gamma Project',
+    language_name: 'Quechua',
+    has_audio: true,
+    has_text: false,
+    completed_chapters: 0,
+    total_chapters: 1189,
+    progress_percentage: 0,
+  },
+];
+
+describe('LanguagesPage', () => {
+  beforeEach(() => {
+    mockUseActiveProjectsWithProgress.mockReset();
+  });
+
+  it('renders the loading spinner while data is loading', () => {
+    setHookReturn({ data: undefined, isLoading: true });
+
+    const { container } = render(<LanguagesPage />);
+
+    expect(container.querySelector('.animate-spin')).not.toBeNull();
+  });
+
+  it('shows the empty state when no projects are returned', () => {
+    setHookReturn({ data: [], isLoading: false });
+
+    render(<LanguagesPage />);
+
+    expect(screen.getByText('No projects available')).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /Active projects will appear here once they have translation progress/i
+      )
+    ).toBeInTheDocument();
+  });
+
+  it('renders one row per active project with progress chip', () => {
+    setHookReturn({ data: sampleProjects, isLoading: false });
+
+    render(<LanguagesPage />);
+
+    expect(screen.getByText('Bajhangi')).toBeInTheDocument();
+    expect(screen.getByText('Alpha Project')).toBeInTheDocument();
+    expect(screen.getByText('50.0%')).toBeInTheDocument();
+
+    expect(screen.getByText('Tagalog')).toBeInTheDocument();
+    expect(screen.getByText('100%')).toBeInTheDocument();
+
+    expect(screen.getByText('Quechua')).toBeInTheDocument();
+    expect(screen.getByText('0%')).toBeInTheDocument();
+  });
+
+  it('filters rows by language name (case insensitive)', () => {
+    setHookReturn({ data: sampleProjects, isLoading: false });
+
+    render(<LanguagesPage />);
+
+    fireEvent.change(
+      screen.getByPlaceholderText(/Search by language name or project name/i),
+      { target: { value: 'taga' } }
+    );
+
+    expect(screen.getByText('Tagalog')).toBeInTheDocument();
+    expect(screen.queryByText('Bajhangi')).not.toBeInTheDocument();
+    expect(screen.queryByText('Quechua')).not.toBeInTheDocument();
+  });
+
+  it('filters rows by project name (case insensitive)', () => {
+    setHookReturn({ data: sampleProjects, isLoading: false });
+
+    render(<LanguagesPage />);
+
+    fireEvent.change(
+      screen.getByPlaceholderText(/Search by language name or project name/i),
+      { target: { value: 'gamma' } }
+    );
+
+    expect(screen.getByText('Gamma Project')).toBeInTheDocument();
+    expect(screen.queryByText('Alpha Project')).not.toBeInTheDocument();
+    expect(screen.queryByText('Beta Project')).not.toBeInTheDocument();
+  });
+
+  it('shows only the top N rows when not searching, with a Show all toggle', () => {
+    const many: ActiveProjectWithProgress[] = Array.from(
+      { length: 12 },
+      (_, i) => ({
+        project_id: `p-${i}`,
+        project_name: `Project ${i}`,
+        language_name: `Lang ${i}`,
+        has_audio: true,
+        has_text: false,
+        completed_chapters: i,
+        total_chapters: 100,
+        progress_percentage: i,
+      })
+    );
+
+    setHookReturn({ data: many, isLoading: false });
+
+    render(<LanguagesPage />);
+
+    expect(screen.getByText('Lang 0')).toBeInTheDocument();
+    expect(screen.queryByText('Lang 11')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /Show all 12/i }));
+
+    expect(screen.getByText('Lang 11')).toBeInTheDocument();
+  });
+
+  it('does not render NT/OT chip columns', () => {
+    setHookReturn({ data: sampleProjects, isLoading: false });
+
+    render(<LanguagesPage />);
+
+    expect(screen.queryByText('New Testament')).not.toBeInTheDocument();
+    expect(screen.queryByText('Old Testament')).not.toBeInTheDocument();
+    expect(screen.getByText('Progress')).toBeInTheDocument();
+  });
+
+  it('does not render a Country column', () => {
+    setHookReturn({ data: sampleProjects, isLoading: false });
+
+    render(<LanguagesPage />);
+
+    expect(screen.queryByText('Country')).not.toBeInTheDocument();
+  });
+});

--- a/apps/web-project-dashboard/src/app/pages/LanguagesPage.tsx
+++ b/apps/web-project-dashboard/src/app/pages/LanguagesPage.tsx
@@ -1,223 +1,69 @@
 import React, { useState, useMemo } from 'react';
-import { Search, Globe, MapPin, FolderOpen } from 'lucide-react';
-import { useQuery } from '@tanstack/react-query';
+import { Search, Globe, FolderOpen, BarChart3 } from 'lucide-react';
 import { Input } from '../../shared/design-system/components/Input';
 import { Button } from '../../shared/design-system/components/Button';
 import { LoadingSpinner } from '../../shared/design-system';
 import { LandingNavbar } from '../../features/landing-page/components/LandingNavbar';
-import { supabase } from '../../shared/services/supabase';
+import {
+  useActiveProjectsWithProgress,
+  type ActiveProjectWithProgress,
+} from '../../shared/hooks/query/projects';
 import { LandingFooter } from '@/features/landing-page';
 
-interface LanguageWithProject {
+interface LanguageRow {
   id: string;
   motherTongue: string;
-  country: string;
   projectName: string;
-  projectId: string;
-  newTestament: number;
-  oldTestament: number;
-  totalProgress: number;
+  completedChapters: number;
+  totalChapters: number;
+  progressPercentage: number;
 }
 
-// Hook to fetch ALL projects (public view) with their language entities and translation progress
-function useAllProjectsWithLanguages() {
-  return useQuery({
-    queryKey: ['all-projects-with-languages-public'],
-    queryFn: async () => {
-      // Fetch ALL projects with their target language entity and region
-      // This is a public view - fetches all projects regardless of user
-      const { data: projects, error: projectsError } = await supabase
-        .from('projects')
-        .select(
-          `
-          id,
-          name,
-          target_language_entity_id,
-          region_id,
-          publish_status,
-          target_language:language_entities!target_language_entity_id (
-            id,
-            name,
-            level
-          ),
-          region:regions!region_id (
-            id,
-            name,
-            level
-          )
-        `
-        )
-        .order('created_at', { ascending: false });
+const TOP_N = 10;
 
-      if (projectsError) throw projectsError;
-      if (!projects || projects.length === 0) return [];
-
-      // Get all project IDs
-      const projectIds = projects.map(p => p.id);
-
-      // Fetch audio versions for all projects
-      const { data: audioVersions, error: audioError } = await supabase
-        .from('audio_versions')
-        .select('id, project_id')
-        .in('project_id', projectIds);
-
-      if (audioError) throw audioError;
-
-      // Group audio versions by project
-      const audioVersionsByProject = new Map<string, string[]>();
-      audioVersions?.forEach(av => {
-        if (av.project_id) {
-          if (!audioVersionsByProject.has(av.project_id)) {
-            audioVersionsByProject.set(av.project_id, []);
-          }
-          audioVersionsByProject.get(av.project_id)!.push(av.id);
-        }
-      });
-
-      // Get all audio version IDs
-      const allAudioVersionIds = audioVersions?.map(av => av.id) || [];
-
-      // Fetch media files with their chapter and book info to calculate translation progress
-      let mediaFilesWithBooks: Array<{
-        audio_version_id: string;
-        chapter_id: string;
-        chapters: {
-          book_id: string;
-          books: {
-            id: string;
-            testament: string | null;
-          } | null;
-        } | null;
-      }> = [];
-
-      if (allAudioVersionIds.length > 0) {
-        const { data: mediaFiles, error: mediaError } = await supabase
-          .from('media_files')
-          .select(
-            `
-            audio_version_id,
-            chapter_id,
-            chapters!inner (
-              book_id,
-              books!inner (
-                id,
-                testament
-              )
-            )
-          `
-          )
-          .in('audio_version_id', allAudioVersionIds)
-          .not('chapter_id', 'is', null);
-
-        if (mediaError) throw mediaError;
-        mediaFilesWithBooks = (mediaFiles || []) as typeof mediaFilesWithBooks;
-      }
-
-      // Calculate translation progress per project
-      const progressByProject = new Map<
-        string,
-        { nt: Set<string>; ot: Set<string> }
-      >();
-
-      mediaFilesWithBooks.forEach(mf => {
-        // Find which project this audio version belongs to
-        let projectId: string | null = null;
-        for (const [pId, avIds] of audioVersionsByProject.entries()) {
-          if (avIds.includes(mf.audio_version_id)) {
-            projectId = pId;
-            break;
-          }
-        }
-
-        if (projectId && mf.chapters?.books) {
-          if (!progressByProject.has(projectId)) {
-            progressByProject.set(projectId, { nt: new Set(), ot: new Set() });
-          }
-
-          const progress = progressByProject.get(projectId)!;
-          const bookId = mf.chapters.books.id;
-          const testament = mf.chapters.books.testament;
-
-          if (testament === 'NT') {
-            progress.nt.add(bookId);
-          } else if (testament === 'OT') {
-            progress.ot.add(bookId);
-          }
-        }
-      });
-
-      // Transform projects to table rows
-      const allProjectRows = projects.map(project => {
-        const progress = progressByProject.get(project.id);
-        const targetLang = project.target_language as {
-          id: string;
-          name: string;
-          level: string;
-        } | null;
-        const region = project.region as {
-          id: string;
-          name: string;
-          level: string;
-        } | null;
-
-        return {
-          id: project.id,
-          motherTongue: targetLang?.name || 'Unknown',
-          country: region?.name || 'Unknown',
-          projectName: project.name,
-          projectId: project.id,
-          newTestament: progress?.nt.size || 0,
-          oldTestament: progress?.ot.size || 0,
-          totalProgress: (progress?.nt.size || 0) + (progress?.ot.size || 0),
-        };
-      });
-
-      // Sort by total translation progress (most progress first), then by name
-      allProjectRows.sort((a, b) => {
-        if (b.totalProgress !== a.totalProgress) {
-          return b.totalProgress - a.totalProgress;
-        }
-        return a.projectName.localeCompare(b.projectName);
-      });
-
-      return allProjectRows;
-    },
-    staleTime: 5 * 60 * 1000, // 5 minutes
-  });
+function toLanguageRow(project: ActiveProjectWithProgress): LanguageRow {
+  return {
+    id: project.project_id,
+    motherTongue: project.language_name ?? 'Unknown',
+    projectName: project.project_name ?? 'Unknown project',
+    completedChapters: project.completed_chapters ?? 0,
+    totalChapters: project.total_chapters ?? 0,
+    progressPercentage: Number(project.progress_percentage ?? 0),
+  };
 }
 
 export const LanguagesPage: React.FC = () => {
   const [searchQuery, setSearchQuery] = useState('');
   const [showAll, setShowAll] = useState(false);
 
-  // Fetch ALL projects with languages (public view)
-  const { data: allProjects = [], isLoading } = useAllProjectsWithLanguages();
+  const { data: rpcData = [], isLoading } = useActiveProjectsWithProgress();
 
-  // Filter and limit projects based on search query
-  const tableData: LanguageWithProject[] = useMemo(() => {
+  const allProjects: LanguageRow[] = useMemo(
+    () => rpcData.map(toLanguageRow),
+    [rpcData]
+  );
+
+  const tableData: LanguageRow[] = useMemo(() => {
     let filtered = allProjects;
 
-    // If there's a search query, filter by it
     if (searchQuery.trim()) {
       const query = searchQuery.toLowerCase().trim();
       filtered = allProjects.filter(
         project =>
           project.motherTongue.toLowerCase().includes(query) ||
-          project.country.toLowerCase().includes(query) ||
           project.projectName.toLowerCase().includes(query)
       );
     }
 
-    // If not searching and not showing all, limit to top 10
     if (!searchQuery.trim() && !showAll) {
-      return filtered.slice(0, 10);
+      return filtered.slice(0, TOP_N);
     }
 
     return filtered;
   }, [allProjects, searchQuery, showAll]);
 
   const hasMoreProjects =
-    !searchQuery.trim() && !showAll && allProjects.length > 10;
+    !searchQuery.trim() && !showAll && allProjects.length > TOP_N;
 
   return (
     <div className='min-h-screen bg-neutral-50 dark:bg-neutral-950 text-neutral-900 dark:text-white'>
@@ -257,7 +103,7 @@ export const LanguagesPage: React.FC = () => {
             <Input
               value={searchQuery}
               onChange={e => setSearchQuery(e.target.value)}
-              placeholder='Search by language name, country, or project name...'
+              placeholder='Search by language name or project name...'
               className='pl-12 h-14 text-lg rounded-2xl border-2 border-neutral-200 dark:border-neutral-700 bg-white dark:bg-neutral-900 shadow-lg shadow-neutral-200/50 dark:shadow-none focus:border-accent-500 dark:focus:border-accent-400'
             />
           </div>
@@ -266,24 +112,18 @@ export const LanguagesPage: React.FC = () => {
         {/* Results Table */}
         <div className='bg-white dark:bg-neutral-900 rounded-2xl border border-neutral-200 dark:border-neutral-800 shadow-xl shadow-neutral-200/50 dark:shadow-none overflow-hidden'>
           {/* Table Header */}
-          <div className='grid grid-cols-5 gap-4 px-6 py-4 bg-neutral-50 dark:bg-neutral-800/50 border-b border-neutral-200 dark:border-neutral-700'>
+          <div className='grid grid-cols-[1.25fr_1.75fr_1.5fr] gap-4 px-6 py-4 bg-neutral-50 dark:bg-neutral-800/50 border-b border-neutral-200 dark:border-neutral-700'>
             <div className='flex items-center gap-2 text-sm font-semibold text-neutral-700 dark:text-neutral-300 uppercase tracking-wider'>
               <Globe className='h-4 w-4 text-accent-500' />
               Mother Tongue
             </div>
             <div className='flex items-center gap-2 text-sm font-semibold text-neutral-700 dark:text-neutral-300 uppercase tracking-wider'>
-              <MapPin className='h-4 w-4 text-accent-500' />
-              Country
-            </div>
-            <div className='flex items-center gap-2 text-sm font-semibold text-neutral-700 dark:text-neutral-300 uppercase tracking-wider'>
               <FolderOpen className='h-4 w-4 text-accent-500' />
               Project
             </div>
-            <div className='text-sm font-semibold text-neutral-700 dark:text-neutral-300 uppercase tracking-wider text-center'>
-              New Testament
-            </div>
-            <div className='text-sm font-semibold text-neutral-700 dark:text-neutral-300 uppercase tracking-wider text-center'>
-              Old Testament
+            <div className='flex items-center gap-2 text-sm font-semibold text-neutral-700 dark:text-neutral-300 uppercase tracking-wider justify-end'>
+              <BarChart3 className='h-4 w-4 text-accent-500' />
+              Progress
             </div>
           </div>
 
@@ -302,50 +142,12 @@ export const LanguagesPage: React.FC = () => {
                 <p className='text-sm'>
                   {searchQuery
                     ? 'Try a different search term or check the spelling'
-                    : 'Projects will appear here once they are created'}
+                    : 'Active projects will appear here once they have translation progress'}
                 </p>
               </div>
             ) : (
               tableData.map((row, index) => (
-                <div
-                  key={`${row.id}-${index}`}
-                  className='grid grid-cols-5 gap-4 px-6 py-4 hover:bg-neutral-50 dark:hover:bg-neutral-800/30 transition-colors'>
-                  <div className='font-medium text-neutral-900 dark:text-white'>
-                    {row.motherTongue}
-                  </div>
-                  <div className='text-neutral-600 dark:text-neutral-400'>
-                    {row.country}
-                  </div>
-                  <div
-                    className='text-neutral-600 dark:text-neutral-400 truncate'
-                    title={row.projectName}>
-                    {row.projectName}
-                  </div>
-                  <div className='text-center'>
-                    <span
-                      className={`inline-flex items-center justify-center min-w-[3rem] px-3 py-1 rounded-full text-sm font-semibold ${
-                        row.newTestament > 0
-                          ? row.newTestament === 27
-                            ? 'bg-green-100 dark:bg-green-500/20 text-green-700 dark:text-green-400'
-                            : 'bg-amber-100 dark:bg-amber-500/10 text-amber-700 dark:text-amber-400'
-                          : 'bg-neutral-100 dark:bg-neutral-800 text-neutral-500 dark:text-neutral-500'
-                      }`}>
-                      {row.newTestament}/27
-                    </span>
-                  </div>
-                  <div className='text-center'>
-                    <span
-                      className={`inline-flex items-center justify-center min-w-[3rem] px-3 py-1 rounded-full text-sm font-semibold ${
-                        row.oldTestament > 0
-                          ? row.oldTestament === 39
-                            ? 'bg-blue-100 dark:bg-blue-500/20 text-blue-700 dark:text-blue-400'
-                            : 'bg-amber-100 dark:bg-amber-500/10 text-amber-700 dark:text-amber-400'
-                          : 'bg-neutral-100 dark:bg-neutral-800 text-neutral-500 dark:text-neutral-500'
-                      }`}>
-                      {row.oldTestament}/39
-                    </span>
-                  </div>
-                </div>
+                <ProgressRow key={`${row.id}-${index}`} row={row} />
               ))
             )}
           </div>
@@ -360,8 +162,8 @@ export const LanguagesPage: React.FC = () => {
                 {searchQuery && ` matching "${searchQuery}"`}
                 {!searchQuery &&
                   !showAll &&
-                  allProjects.length > 10 &&
-                  ' (top 10 by progress)'}
+                  allProjects.length > TOP_N &&
+                  ` (top ${TOP_N} by progress)`}
               </span>
               {hasMoreProjects && (
                 <Button
@@ -372,13 +174,13 @@ export const LanguagesPage: React.FC = () => {
                   Show all {allProjects.length} projects
                 </Button>
               )}
-              {showAll && !searchQuery && allProjects.length > 10 && (
+              {showAll && !searchQuery && allProjects.length > TOP_N && (
                 <Button
                   variant='ghost'
                   size='sm'
                   onClick={() => setShowAll(false)}
                   className='text-accent-600 dark:text-accent-400 hover:text-accent-700 dark:hover:text-accent-300'>
-                  Show top 10 only
+                  Show top {TOP_N} only
                 </Button>
               )}
             </div>
@@ -391,10 +193,10 @@ export const LanguagesPage: React.FC = () => {
             About Translation Progress
           </h3>
           <p className='text-neutral-600 dark:text-neutral-400 text-sm leading-relaxed'>
-            The New Testament contains 27 books, and the Old Testament contains
-            39 books. The numbers shown indicate how many books have been
-            translated into each language. A complete Bible translation includes
-            all 66 books.
+            Progress is measured at the chapter level across each project's
+            audio and text versions. The number shown is the percentage of
+            translated chapters out of the project's total chapter count, with
+            chapters completed and total displayed alongside.
           </p>
         </div>
       </main>
@@ -403,3 +205,70 @@ export const LanguagesPage: React.FC = () => {
     </div>
   );
 };
+
+interface ProgressRowProps {
+  row: LanguageRow;
+}
+
+const ProgressRow: React.FC<ProgressRowProps> = ({ row }) => {
+  const pct = clampPercentage(row.progressPercentage);
+  const tone = progressTone(pct);
+
+  return (
+    <div className='grid grid-cols-[1.25fr_1.75fr_1.5fr] gap-4 px-6 py-4 hover:bg-neutral-50 dark:hover:bg-neutral-800/30 transition-colors items-center'>
+      <div
+        className='font-medium text-neutral-900 dark:text-white truncate'
+        title={row.motherTongue}>
+        {row.motherTongue}
+      </div>
+      <div
+        className='text-neutral-600 dark:text-neutral-400 truncate'
+        title={row.projectName}>
+        {row.projectName}
+      </div>
+      <div className='flex items-center gap-3 justify-end'>
+        <div
+          className='hidden sm:block w-24 md:w-32 h-2 rounded-full bg-neutral-100 dark:bg-neutral-800 overflow-hidden'
+          aria-hidden='true'>
+          <div className={`h-full ${tone.bar}`} style={{ width: `${pct}%` }} />
+        </div>
+        <span
+          className={`inline-flex items-center justify-center min-w-[3.5rem] px-3 py-1 rounded-full text-sm font-semibold ${tone.chip}`}
+          title={`${row.completedChapters} of ${row.totalChapters} chapters`}>
+          {pct.toFixed(pct >= 100 || pct === 0 ? 0 : 1)}%
+        </span>
+      </div>
+    </div>
+  );
+};
+
+function clampPercentage(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  if (value < 0) return 0;
+  if (value > 100) return 100;
+  return value;
+}
+
+interface ProgressTone {
+  bar: string;
+  chip: string;
+}
+
+function progressTone(pct: number): ProgressTone {
+  if (pct >= 100) {
+    return {
+      bar: 'bg-green-500 dark:bg-green-400',
+      chip: 'bg-green-100 dark:bg-green-500/20 text-green-700 dark:text-green-400',
+    };
+  }
+  if (pct > 0) {
+    return {
+      bar: 'bg-amber-500 dark:bg-amber-400',
+      chip: 'bg-amber-100 dark:bg-amber-500/10 text-amber-700 dark:text-amber-400',
+    };
+  }
+  return {
+    bar: 'bg-neutral-300 dark:bg-neutral-700',
+    chip: 'bg-neutral-100 dark:bg-neutral-800 text-neutral-500 dark:text-neutral-500',
+  };
+}

--- a/apps/web-project-dashboard/src/shared/hooks/query/projects.ts
+++ b/apps/web-project-dashboard/src/shared/hooks/query/projects.ts
@@ -3,8 +3,35 @@ import { useQuery } from '@tanstack/react-query';
 import type { TableRow, SupabaseError } from './base-hooks';
 import { supabase } from '../../services/supabase';
 import { useAuth } from '../../../features/auth/hooks/useAuth';
+import type { Database } from '@everylanguage/shared-types';
 
 export type Project = TableRow<'projects'>;
+
+export type ActiveProjectWithProgress =
+  Database['public']['Functions']['get_active_projects_with_progress']['Returns'][number];
+
+// Hook to fetch active projects with aggregated progress via the public RPC.
+// Uses get_active_projects_with_progress(), which:
+//   * is exposed to the anon role (works on public/unauthenticated routes),
+//   * filters to project_status = 'active' and projects with at least one
+//     audio or text version that has progress data,
+//   * returns a single row per project with language_name + progress totals,
+//     ordered by progress_percentage DESC NULLS LAST.
+export function useActiveProjectsWithProgress() {
+  return useQuery<ActiveProjectWithProgress[], SupabaseError>({
+    queryKey: ['active-projects-with-progress'],
+    queryFn: async (): Promise<ActiveProjectWithProgress[]> => {
+      const { data, error } = await supabase
+        .rpc('get_active_projects_with_progress')
+        .returns<ActiveProjectWithProgress[]>();
+
+      if (error) throw transformError(error);
+
+      return data ?? [];
+    },
+    staleTime: 5 * 60 * 1000, // 5 minutes
+  });
+}
 
 // Hook to fetch all projects
 export function useProjects() {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
fixes EL-216

## Problem

The Language Explorer at `/languages` (`apps/web-project-dashboard/src/app/pages/LanguagesPage.tsx`) is a public/unauthenticated route, but it queried `projects` directly from the browser using the anon publishable key. The active SELECT RLS policy `projects_select_public` (last redefined in `supabase/migrations/20251226000098_fix_projects_rls_auth_uid_initplan.sql`) only exposes rows where `publish_status = 'published'` to the anon role, so the search had nothing to match against and the page rendered "No languages found" / "No projects available" for every term.

The previous implementation also issued 3+ chained queries from the browser (`projects` → `audio_versions` → `media_files` + `chapters` + `books`) and recomputed NT/OT progress in JS on every load.

## Fix

Replace the in-page multi-query hook with a TanStack Query hook that calls the existing public RPC `get_active_projects_with_progress()` (defined in `supabase/migrations/20251231200000_fix_get_active_projects_with_progress_filter.sql`, also used by `web-partnership-dashboard` for its global stats panel).

The RPC:
- is callable by the anon role, so it works on this public route,
- already filters to `project_status = 'active'` and projects with at least one audio or text version with progress,
- returns one row per project with `language_name`, `completed_chapters`, `total_chapters`, `progress_percentage`, ordered by `progress_percentage DESC NULLS LAST`.

### Per product decisions in the Slack thread

1. NT/OT chip columns are replaced with a single **Progress** column showing `progress_percentage`, with a small bar and a tooltip showing `completed / total` chapters.
2. The **Country** column is dropped — the RPC does not return region data, and per the product call we are not extending the RPC for this fix.
3. Only **active** projects are shown — the RPC already enforces `project_status = 'active'`.

## Changes

- `apps/web-project-dashboard/src/shared/hooks/query/projects.ts`: add `useActiveProjectsWithProgress` hook + exported `ActiveProjectWithProgress` type derived from `Database['public']['Functions']['get_active_projects_with_progress']['Returns'][number]`.
- `apps/web-project-dashboard/src/app/pages/LanguagesPage.tsx`: switch to the new hook; collapse the table to 3 columns (Mother Tongue, Project, Progress); update copy on the empty state and the Info Card to describe chapter-level progress; keep top-N + Show all behavior and search by language name + project name.
- `apps/web-project-dashboard/src/app/pages/LanguagesPage.test.tsx`: new tests covering loading, empty, populated, search by language and project name (case-insensitive), top-N + Show all toggle, and absence of NT/OT/Country columns.

## Verification

- `pnpm --filter=web-project-dashboard type-check` ✅
- `pnpm --filter=web-project-dashboard lint` ✅
- `pnpm --filter=web-project-dashboard test:run -- LanguagesPage` ✅ (8/8)

### Acceptance criteria status

- [x] Visiting `/languages` while logged out renders ≥1 row in environments with at least one active project that has progress (RPC is anon-callable and bypasses the `publish_status` policy issue).
- [x] Searching by language name or project name filters the visible rows (case-insensitive).
- [x] Empty-search state shows the top-10 by progress with a "Show all" toggle.
- [x] Empty-DB state still shows a friendly empty state.
- [x] Page makes ≤1 network round trip on load (single RPC call).
- [x] No `any`; explicit return types on every new function/hook.
- [x] Lint, type-check, and the new unit tests pass.

### Manual E2E (suggested, requires a working dev DB)

1. `pnpm db:dev`
2. `pnpm --filter=web-project-dashboard dev`, open `http://localhost:5175/languages` while signed out → expect rows for each active seed project with progress.
3. Type a known language name → expect filtered row(s).
4. Sign in and repeat → results identical (RPC ignores auth state).
5. Verify network panel: exactly one POST to `/rest/v1/rpc/get_active_projects_with_progress`.

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://automationbogts.slack.com/archives/C0B0MNN256V/p1777346315386549?thread_ts=1777346315.386549&cid=C0B0MNN256V)

<div><a href="https://cursor.com/agents/bc-13ea5161-8c0d-577a-9e6e-bd4c4f6c6765"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-13ea5161-8c0d-577a-9e6e-bd4c4f6c6765"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

